### PR TITLE
should use only one child in Router

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,12 @@ import HomePage from "./pages/HomePage"
 
 ReactDOM.render(
   <Router>
+   <section className='app'>
     <Route exact path="/" component={AppLayout} />
     <Switch>
       <Route path="/home" component={HomePage} />
     </Switch>
+   </section>
   </Router>,
   document.getElementById("root")
 )


### PR DESCRIPTION
According to the error, you asked at an hour ago like this.

```
ใช้ layout component + react router 4 มันขึ้น A <Router> may have only one child element ต้องดูตรงไหนบ้าง
```

this error is represented to ```<Router>``` Component has to be only one "Child". 

# How 2 resolve them.
I wrapped to only one child by HTML tag ```<section>```.  So u can pick any tag was you like to wrap together.

Cheers.